### PR TITLE
SLING-9043 Adding COPY/MOVE method in default methods list of protected HTTP methods

### DIFF
--- a/src/main/java/org/apache/sling/security/impl/ReferrerFilter.java
+++ b/src/main/java/org/apache/sling/security/impl/ReferrerFilter.java
@@ -131,7 +131,7 @@ public class ReferrerFilter implements  Preprocessor {
                 name = "Filter Methods",
                 description = "These methods are filtered by the filter"
         )
-        String[] filter_methods() default {"POST", "PUT", "DELETE"};
+        String[] filter_methods() default {"POST", "PUT", "DELETE", "COPY", "MOVE"};
 
         /**
          * Excluded regexp user agents property


### PR DESCRIPTION
COPY being a state changing action, this must be behind proper CSRF protection.