### PR TITLE
build: upgrade parent POM to v66 and migrate to Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling-bundle-parent</artifactId>
-        <version>46</version>
+        <version>66</version>
         <relativePath />
     </parent>
 
@@ -31,37 +31,35 @@
     <version>1.3.1-SNAPSHOT</version>
 
     <name>Apache Sling Security</name>
-    <description>
-        The Apache Sling Security module.
-    </description>
-
-    <properties>
-        <project.build.outputTimestamp>1</project.build.outputTimestamp>
-    </properties>
+    <description>The Apache Sling Security module.</description>
 
     <scm>
         <connection>scm:git:https://gitbox.apache.org/repos/asf/sling-org-apache-sling-security.git</connection>
         <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/sling-org-apache-sling-security.git</developerConnection>
+        <tag>org.apache.sling.security-1.3.0</tag>
         <url>https://github.com/apache/sling-org-apache-sling-security.git</url>
-      <tag>org.apache.sling.security-1.3.0</tag>
-  </scm>
+    </scm>
+
+    <properties>
+        <sling.java.version>11</sling.java.version>
+        <project.build.outputTimestamp>2024-01-01T00:00:00Z</project.build.outputTimestamp>
+    </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.component.annotations</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.metatype.annotations</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
@@ -78,6 +76,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>
@@ -89,10 +88,12 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jmock</groupId>
@@ -102,8 +103,8 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -113,5 +114,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
 </project>

--- a/src/main/java/org/apache/sling/security/impl/ContentDispositionFilter.java
+++ b/src/main/java/org/apache/sling/security/impl/ContentDispositionFilter.java
@@ -1,20 +1,29 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.sling.security.impl;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -25,13 +34,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
@@ -45,14 +47,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Component(
-    service = Filter.class,
-    property={
-        "sling.filter.scope=request",
-        "sling.filter.scope=forward",
-        "service.ranking:Integer=25000"
-    }
-)
-@Designate(ocd=ContentDispositionFilterConfiguration.class)
+        service = Filter.class,
+        property = {"sling.filter.scope=request", "sling.filter.scope=forward", "service.ranking:Integer=25000"})
+@Designate(ocd = ContentDispositionFilterConfiguration.class)
 public class ContentDispositionFilter implements Filter {
 
     /**
@@ -95,7 +92,9 @@ public class ContentDispositionFilter implements Filter {
 
                     if (colonIdx > -1 && colonIdx < idx) {
                         // ':'  in paths is not allowed
-                        logger.info("wildcard ('*') in content type is not allowed, but found content type with value '{}'", path.substring(colonIdx));
+                        logger.info(
+                                "wildcard ('*') in content type is not allowed, but found content type with value '{}'",
+                                path.substring(colonIdx));
                     } else {
                         String p = null;
                         if (idx >= 0) {
@@ -120,7 +119,6 @@ public class ContentDispositionFilter implements Filter {
                             contentTypesMap.put(p, contentTypes);
                         }
                     }
-
                 }
             }
         }
@@ -130,15 +128,19 @@ public class ContentDispositionFilter implements Filter {
 
         enableContentDispositionAllPaths = configuration.sling_content_disposition_all_paths();
 
-
-        String[] contentDispositionExcludedPathsArray = configuration.sling_content_disposition_excluded_paths() != null ? configuration.sling_content_disposition_excluded_paths() : new String[]{};
+        String[] contentDispositionExcludedPathsArray = configuration.sling_content_disposition_excluded_paths() != null
+                ? configuration.sling_content_disposition_excluded_paths()
+                : new String[] {};
 
         contentDispositionExcludedPaths = new HashSet<>(Arrays.asList(contentDispositionExcludedPathsArray));
 
-        logger.info("Initialized. content disposition paths: {}, content disposition paths-pfx {}, content disposition excluded paths: {}. Enable Content Disposition for all paths is set to {}",
-                contentDispositionPaths, contentDispositionPathsPfx, contentDispositionExcludedPaths, enableContentDispositionAllPaths);
+        logger.info(
+                "Initialized. content disposition paths: {}, content disposition paths-pfx {}, content disposition excluded paths: {}. Enable Content Disposition for all paths is set to {}",
+                contentDispositionPaths,
+                contentDispositionPathsPfx,
+                contentDispositionExcludedPaths,
+                enableContentDispositionAllPaths);
     }
-
 
     @Override
     public void init(FilterConfig filterConfig) {
@@ -151,8 +153,8 @@ public class ContentDispositionFilter implements Filter {
     }
 
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response,
-                         FilterChain chain) throws IOException, ServletException {
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
 
         final SlingHttpServletRequest slingRequest = (SlingHttpServletRequest) request;
         final SlingHttpServletResponse slingResponse = (SlingHttpServletResponse) response;
@@ -162,7 +164,7 @@ public class ContentDispositionFilter implements Filter {
         chain.doFilter(request, rewriterResponse);
     }
 
-    //---------- PRIVATE METHODS ---------
+    // ---------- PRIVATE METHODS ---------
 
     private static Set<String> getContentTypes(String contentTypes) {
         Set<String> contentTypesSet = new HashSet<>();
@@ -173,7 +175,7 @@ public class ContentDispositionFilter implements Filter {
         return contentTypesSet;
     }
 
-    //----------- INNER CLASSES ------------
+    // ----------- INNER CLASSES ------------
 
     protected class RewriterResponse extends SlingHttpServletResponseWrapper {
 
@@ -255,7 +257,6 @@ public class ContentDispositionFilter implements Filter {
                                         setContentDisposition(resource);
                                         break;
                                     }
-
                                 }
                             }
                         }
@@ -265,7 +266,7 @@ public class ContentDispositionFilter implements Filter {
             super.setContentType(type);
         }
 
-        //---------- PRIVATE METHODS ---------
+        // ---------- PRIVATE METHODS ---------
 
         private boolean setContentDisposition(Resource resource) {
             boolean contentDispositionAdded = false;

--- a/src/main/java/org/apache/sling/security/impl/ContentDispositionFilterConfiguration.java
+++ b/src/main/java/org/apache/sling/security/impl/ContentDispositionFilterConfiguration.java
@@ -1,38 +1,51 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.sling.security.impl;
 
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
-@ObjectClassDefinition(name="Apache Sling Content Disposition Filter", description="Request filter adding Content Disposition header with value 'attachment' for certain paths/content types. Independent of the configuration only resource paths are covered which contain a property named 'jcr:data' or 'jcr:content\\jcr:data'.")
+@ObjectClassDefinition(
+        name = "Apache Sling Content Disposition Filter",
+        description =
+                "Request filter adding Content Disposition header with value 'attachment' for certain paths/content types. Independent of the configuration only resource paths are covered which contain a property named 'jcr:data' or 'jcr:content\\jcr:data'.")
 public @interface ContentDispositionFilterConfiguration {
 
-    @AttributeDefinition(name="Included Resource Paths & Content Types", description="These resource paths are covered by the filter. "+
-            "Each entry is of the form '<path> [ : <excluded content type> {,<excluded content type>} ]'. " +
-            "Invalid entries are logged and ignored. <path> must be an absolute path and may contain a wildcard ('*') at the end, to match every resource path with the given path prefix.")
+    @AttributeDefinition(
+            name = "Included Resource Paths & Content Types",
+            description =
+                    "These resource paths are covered by the filter. "
+                            + "Each entry is of the form '<path> [ : <excluded content type> {,<excluded content type>} ]'. "
+                            + "Invalid entries are logged and ignored. <path> must be an absolute path and may contain a wildcard ('*') at the end, to match every resource path with the given path prefix.")
     String[] sling_content_disposition_paths() default {};
 
-    @AttributeDefinition(name="Excluded Resource Paths", description="These resource paths are excluded from the filter. "+
-                    "Each resource path must be given as absolute and fully qualified path. Prefix matching/wildcards are not supported.")
+    @AttributeDefinition(
+            name = "Excluded Resource Paths",
+            description =
+                    "These resource paths are excluded from the filter. "
+                            + "Each resource path must be given as absolute and fully qualified path. Prefix matching/wildcards are not supported.")
     String[] sling_content_disposition_excluded_paths() default {};
 
-    @AttributeDefinition(name="Enable For All Resource Paths", description="This flag controls whether to enable" +
-            " this filter for all paths, except for the excluded paths defined by sling.content.disposition.excluded.paths. Setting this to 'true' leads to ignoring 'sling.content.disposition.path'.")
+    @AttributeDefinition(
+            name = "Enable For All Resource Paths",
+            description =
+                    "This flag controls whether to enable"
+                            + " this filter for all paths, except for the excluded paths defined by sling.content.disposition.excluded.paths. Setting this to 'true' leads to ignoring 'sling.content.disposition.path'.")
     boolean sling_content_disposition_all_paths() default false;
-
 }

--- a/src/main/java/org/apache/sling/security/impl/ReferrerFilter.java
+++ b/src/main/java/org/apache/sling/security/impl/ReferrerFilter.java
@@ -1,20 +1,30 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.sling.security.impl;
+
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -35,14 +45,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -59,12 +61,12 @@ import org.slf4j.LoggerFactory;
 @Component(
         service = Preprocessor.class,
         property = {
-                HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_SELECT + "=(" + HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_NAME + "=*)",
-                "felix.webconsole.label=slingreferrerfilter",
-                "felix.webconsole.title=Sling Referrer Filter",
-                "felix.webconsole.configprinter.modes=always"
-        }
-)
+            HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_SELECT + "=("
+                    + HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_NAME + "=*)",
+            "felix.webconsole.label=slingreferrerfilter",
+            "felix.webconsole.title=Sling Referrer Filter",
+            "felix.webconsole.configprinter.modes=always"
+        })
 @Designate(ocd = ReferrerFilter.Config.class)
 public class ReferrerFilter implements Preprocessor {
 
@@ -96,17 +98,14 @@ public class ReferrerFilter implements Preprocessor {
 
     @ObjectClassDefinition(
             name = "Apache Sling Referrer Filter",
-            description = "Request filter checking the referrer of modification requests and denying request with a 403 in case the referrer is not allowed"
-    )
+            description =
+                    "Request filter checking the referrer of modification requests and denying request with a 403 in case the referrer is not allowed")
     public @interface Config {
 
         /**
          * Allow empty property.
          */
-        @AttributeDefinition(
-                name = "Allow Empty",
-                description = "Allow an empty or missing referrer"
-        )
+        @AttributeDefinition(name = "Allow Empty", description = "Allow an empty or missing referrer")
         boolean allow_empty() default false;
 
         /**
@@ -114,12 +113,12 @@ public class ReferrerFilter implements Preprocessor {
          */
         @AttributeDefinition(
                 name = "Allow Hosts",
-                description = "List of allowed hosts for the referrer which are added to the list of default hosts. "
-                        + "It is matched against the full referrer URL in the format \"<scheme>://<host>:<port>\". "
-                        + "If port is 0, it is not taken into consideration. The default list contains all host names "
-                        + "and IPs bound to all NICs found in the system plus \"localhost\", \"127.0.0.1\", \"[::1]\" for protocols \"http\" and \"https\". "
-                        + "If given value does not have a \":\" entries for both http and https are transparently generated."
-        )
+                description =
+                        "List of allowed hosts for the referrer which are added to the list of default hosts. "
+                                + "It is matched against the full referrer URL in the format \"<scheme>://<host>:<port>\". "
+                                + "If port is 0, it is not taken into consideration. The default list contains all host names "
+                                + "and IPs bound to all NICs found in the system plus \"localhost\", \"127.0.0.1\", \"[::1]\" for protocols \"http\" and \"https\". "
+                                + "If given value does not have a \":\" entries for both http and https are transparently generated.")
         String[] allow_hosts() default {};
 
         /**
@@ -129,17 +128,13 @@ public class ReferrerFilter implements Preprocessor {
                 name = "Allow Regexp Host",
                 description = "List of allowed regular expression for the referrer. "
                         + "It is matched against the full referrer URL in the format \"<scheme>://<host>:<port>\". "
-                        + "Evaluated in addition to the default list and the given allowed hosts (see above)!"
-        )
+                        + "Evaluated in addition to the default list and the given allowed hosts (see above)!")
         String[] allow_hosts_regexp() default {};
 
         /**
          * Filtered methods property
          */
-        @AttributeDefinition(
-                name = "Filter Methods",
-                description = "These methods are filtered by the filter"
-        )
+        @AttributeDefinition(name = "Filter Methods", description = "These methods are filtered by the filter")
         String[] filter_methods() default {"POST", "PUT", "DELETE", "COPY", "MOVE"};
 
         /**
@@ -147,20 +142,15 @@ public class ReferrerFilter implements Preprocessor {
          */
         @AttributeDefinition(
                 name = "Exclude Regexp User Agent",
-                description = "List of regexp for user agents not to check the referrer"
-        )
+                description = "List of regexp for user agents not to check the referrer")
         String[] exclude_agents_regexp() default {};
 
         /**
          * Excluded the configured paths from the referrer check
          */
-        @AttributeDefinition(
-                name = "Exclude Paths",
-                description = "List of paths for which not to check the referrer"
-        )
+        @AttributeDefinition(name = "Exclude Paths", description = "List of paths for which not to check the referrer")
         String[] exclude_paths() default {};
     }
-
 
     /**
      * Do we allow empty referrer?
@@ -266,32 +256,40 @@ public class ReferrerFilter implements Preprocessor {
         return patterns.toArray(new Pattern[0]);
     }
 
-    private Collection<String> mergeValues(String[] primary, List<ReferrerFilterAmendment> amendments,
+    private Collection<String> mergeValues(
+            String[] primary,
+            List<ReferrerFilterAmendment> amendments,
             Function<ReferrerFilterAmendment, String[]> extractor) {
         Set<String> consolidated = new HashSet<>();
         if (primary != null) {
             Arrays.stream(primary).forEach(consolidated::add);
         }
         if (amendments != null) {
-            amendments.stream().map(extractor::apply).forEach(v -> Arrays.stream(v).forEach(consolidated::add));
+            amendments.stream().map(extractor::apply).forEach(v -> Arrays.stream(v)
+                    .forEach(consolidated::add));
         }
         return consolidated;
     }
 
     @Activate
-    public ReferrerFilter(final Config config,
-            @Reference(policyOption = ReferencePolicyOption.GREEDY, cardinality = ReferenceCardinality.MULTIPLE, service=ReferrerFilterAmendment.class) List<ReferrerFilterAmendment> amendments) {
+    public ReferrerFilter(
+            final Config config,
+            @Reference(
+                            policyOption = ReferencePolicyOption.GREEDY,
+                            cardinality = ReferenceCardinality.MULTIPLE,
+                            service = ReferrerFilterAmendment.class)
+                    List<ReferrerFilterAmendment> amendments) {
         this.allowEmpty = config.allow_empty();
-        this.allowedRegexReferrers = createRegexPatterns(
-                mergeValues(config.allow_hosts_regexp(), amendments, a -> a.allowHostsRegex()));
+        this.allowedRegexReferrers =
+                createRegexPatterns(mergeValues(config.allow_hosts_regexp(), amendments, a -> a.allowHostsRegex()));
         this.excludedRegexUserAgents = createRegexPatterns(
                 mergeValues(config.exclude_agents_regexp(), amendments, a -> a.excludeAgentsRegex()));
-        this.excludedPaths = mergeValues(config.exclude_paths(), amendments, a -> a.excludePaths()).toArray(new String[0]);
+        this.excludedPaths = mergeValues(config.exclude_paths(), amendments, a -> a.excludePaths())
+                .toArray(new String[0]);
 
         final Set<String> allowUriReferrers = getDefaultAllowedReferrers();
         if (config.allow_hosts() != null) {
-            allowUriReferrers.addAll(
-                    mergeValues(config.allow_hosts(), amendments, a -> a.allowHosts()));
+            allowUriReferrers.addAll(mergeValues(config.allow_hosts(), amendments, a -> a.allowHosts()));
         }
         this.allowedUriReferrers = createReferrerUrls(allowUriReferrers);
 
@@ -325,9 +323,7 @@ public class ReferrerFilter implements Preprocessor {
     }
 
     @Override
-    public void doFilter(final ServletRequest req,
-                         final ServletResponse res,
-                         final FilterChain chain)
+    public void doFilter(final ServletRequest req, final ServletResponse res, final FilterChain chain)
             throws IOException, ServletException {
         if (req instanceof HttpServletRequest && res instanceof HttpServletResponse) {
             final HttpServletRequest request = (HttpServletRequest) req;
@@ -367,7 +363,8 @@ public class ReferrerFilter implements Preprocessor {
         final int paramStart = referrer.indexOf('?');
         final String hostAndPath = (paramStart == -1 ? referrer : referrer.substring(0, paramStart));
         final int endPos = hostAndPath.indexOf('/', startPos);
-        final String hostPart = (endPos == -1 ? hostAndPath.substring(startPos) : hostAndPath.substring(startPos, endPos));
+        final String hostPart =
+                (endPos == -1 ? hostAndPath.substring(startPos) : hostAndPath.substring(startPos, endPos));
         final int hostNameStart = hostPart.indexOf('@') + 1;
         final int hostNameEnd = hostPart.lastIndexOf(':');
         if (hostNameEnd < hostNameStart) {
@@ -389,7 +386,7 @@ public class ReferrerFilter implements Preprocessor {
         if (isExcludedPath(request)) {
             return true;
         }
-        
+
         String referrer = request.getHeader("referer");
         // use the origin if the referrer is not set
         if (referrer == null || referrer.trim().length() == 0) {
@@ -399,7 +396,10 @@ public class ReferrerFilter implements Preprocessor {
         // check for missing/empty referrer
         if (referrer == null || referrer.trim().length() == 0) {
             if (!this.allowEmpty) {
-                this.logger.info("Rejected empty referrer header for {} request to {}", request.getMethod(), request.getRequestURI());
+                this.logger.info(
+                        "Rejected empty referrer header for {} request to {}",
+                        request.getMethod(),
+                        request.getRequestURI());
             }
             return this.allowEmpty;
         }
@@ -411,7 +411,11 @@ public class ReferrerFilter implements Preprocessor {
         final HostInfo info = getHost(referrer);
         if (info == null) {
             // if this is invalid we just return invalid
-            this.logger.info("Rejected illegal referrer header for {} request to {} : {}", request.getMethod(), request.getRequestURI(), referrer);
+            this.logger.info(
+                    "Rejected illegal referrer header for {} request to {} : {}",
+                    request.getMethod(),
+                    request.getRequestURI(),
+                    referrer);
             return false;
         }
 
@@ -425,7 +429,11 @@ public class ReferrerFilter implements Preprocessor {
         boolean valid = isValidUriReferrer(info) || isValidRegexReferrer(info);
 
         if (!valid) {
-            this.logger.info("Rejected referrer header for {} request to {} : {}", request.getMethod(), request.getRequestURI(), referrer);
+            this.logger.info(
+                    "Rejected referrer header for {} request to {} : {}",
+                    request.getMethod(),
+                    request.getRequestURI(),
+                    referrer);
         }
         return valid;
     }
@@ -493,7 +501,7 @@ public class ReferrerFilter implements Preprocessor {
         }
         return false;
     }
-    
+
     /**
      * Returns <code>true</code> if the provided user agent matches any present exclusion regexp pattern.
      *

--- a/src/main/java/org/apache/sling/security/impl/ReferrerFilterAmendment.java
+++ b/src/main/java/org/apache/sling/security/impl/ReferrerFilterAmendment.java
@@ -1,18 +1,20 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.sling.security.impl;
 

--- a/src/main/java/org/apache/sling/security/impl/ReferrerFilterAmendmentImpl.java
+++ b/src/main/java/org/apache/sling/security/impl/ReferrerFilterAmendmentImpl.java
@@ -1,18 +1,20 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.sling.security.impl;
 
@@ -55,28 +57,37 @@ public class ReferrerFilterAmendmentImpl implements ReferrerFilterAmendment {
         return Optional.ofNullable(config.exclude_paths()).orElse(new String[0]);
     }
 
-    @ObjectClassDefinition(name = "Apache Sling Referrer Filter Amendment", description = "Amend the primary list of Referrer Filter allow hosts with additional hosts")
+    @ObjectClassDefinition(
+            name = "Apache Sling Referrer Filter Amendment",
+            description = "Amend the primary list of Referrer Filter allow hosts with additional hosts")
     public @interface Config {
 
-        @AttributeDefinition(name = "Allow Hosts", description = "List of allowed hosts for the referrer which are added to the list of default hosts. "
-                + "It is matched against the full referrer URL in the format \"<scheme>://<host>:<port>\". "
-                + "If port is 0, it is not taken into consideration. The default list contains all host names "
-                + "and IPs bound to all NICs found in the system plus \"localhost\", \"127.0.0.1\", \"[::1]\" for protocols \"http\" and \"https\". "
-                + "If given value does not have a \":\" entries for both http and https are transparently generated.")
+        @AttributeDefinition(
+                name = "Allow Hosts",
+                description =
+                        "List of allowed hosts for the referrer which are added to the list of default hosts. "
+                                + "It is matched against the full referrer URL in the format \"<scheme>://<host>:<port>\". "
+                                + "If port is 0, it is not taken into consideration. The default list contains all host names "
+                                + "and IPs bound to all NICs found in the system plus \"localhost\", \"127.0.0.1\", \"[::1]\" for protocols \"http\" and \"https\". "
+                                + "If given value does not have a \":\" entries for both http and https are transparently generated.")
         String[] allow_hosts() default {};
 
         /**
          * Allow referrer regex hosts property
          */
-        @AttributeDefinition(name = "Allow Regexp Host", description = "List of allowed regular expression for the referrer. "
-                + "It is matched against the full referrer URL in the format \"<scheme>://<host>:<port>\". "
-                + "Evaluated in addition to the default list and the given allowed hosts (see above)!")
+        @AttributeDefinition(
+                name = "Allow Regexp Host",
+                description = "List of allowed regular expression for the referrer. "
+                        + "It is matched against the full referrer URL in the format \"<scheme>://<host>:<port>\". "
+                        + "Evaluated in addition to the default list and the given allowed hosts (see above)!")
         String[] allow_hosts_regexp() default {};
 
         /**
          * Excluded regexp user agents property
          */
-        @AttributeDefinition(name = "Exclude Regexp User Agent", description = "List of regexp for user agents not to check the referrer")
+        @AttributeDefinition(
+                name = "Exclude Regexp User Agent",
+                description = "List of regexp for user agents not to check the referrer")
         String[] exclude_agents_regexp() default {};
 
         /**
@@ -84,7 +95,5 @@ public class ReferrerFilterAmendmentImpl implements ReferrerFilterAmendment {
          */
         @AttributeDefinition(name = "Exclude Paths", description = "List of paths for which not to check the referrer")
         String[] exclude_paths() default {};
-
     }
-
 }

--- a/src/test/java/org/apache/sling/security/impl/ContentDispositionFilterTest.java
+++ b/src/test/java/org/apache/sling/security/impl/ContentDispositionFilterTest.java
@@ -1,18 +1,20 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.sling.security.impl;
 
@@ -21,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import junitx.util.PrivateAccessor;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
@@ -31,8 +34,6 @@ import org.jmock.Mockery;
 import org.jmock.integration.junit4.JUnit4Mockery;
 import org.junit.Assert;
 import org.junit.Test;
-
-import junitx.util.PrivateAccessor;
 
 public class ContentDispositionFilterTest {
 
@@ -59,22 +60,22 @@ public class ContentDispositionFilterTest {
         private final String paths[];
         private final String excludedPaths[];
         private final boolean enableForAllPaths;
-        
+
         @Override
         public Class<? extends Annotation> annotationType() {
             return ContentDispositionFilterConfiguration.class;
         }
-        
+
         @Override
         public String[] sling_content_disposition_paths() {
             return paths;
         }
-        
+
         @Override
         public String[] sling_content_disposition_excluded_paths() {
             return excludedPaths;
         }
-        
+
         @Override
         public boolean sling_content_disposition_all_paths() {
             return enableForAllPaths;
@@ -84,82 +85,102 @@ public class ContentDispositionFilterTest {
     private void callActivateWithConfiguration(String[] paths, String[] excludedPaths) throws Throwable {
         callActivateWithConfiguration(paths, excludedPaths, false);
     }
-    
 
-    private void callActivateWithConfiguration(String[] paths, String[] excludedPaths, boolean enableForAllPaths) throws Throwable {
-        ContentDispositionFilterConfiguration configuration = new Configuration(paths, excludedPaths, enableForAllPaths);
+    private void callActivateWithConfiguration(String[] paths, String[] excludedPaths, boolean enableForAllPaths)
+            throws Throwable {
+        ContentDispositionFilterConfiguration configuration =
+                new Configuration(paths, excludedPaths, enableForAllPaths);
         contentDispositionFilter = new ContentDispositionFilter(configuration);
     }
 
     @SuppressWarnings("unchecked")
     @Test
-    public void test_activator1() throws Throwable{
-        callActivateWithConfiguration(new String[]{"/content/usergenerated"}, new String []{""});
-        Set<String> contentDispositionPaths = ( Set<String> ) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionPaths");
+    public void test_activator1() throws Throwable {
+        callActivateWithConfiguration(new String[] {"/content/usergenerated"}, new String[] {""});
+        Set<String> contentDispositionPaths =
+                (Set<String>) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionPaths");
         Assert.assertEquals(1, contentDispositionPaths.size());
-        String[] contentDispositionPathsPfx = ( String[] ) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionPathsPfx");
+        String[] contentDispositionPathsPfx =
+                (String[]) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionPathsPfx");
         Assert.assertEquals(0, contentDispositionPathsPfx.length);
-        Map <String, Set<String>> contentTypesMapping = ( Map <String, Set<String>> ) PrivateAccessor.getField(contentDispositionFilter, "contentTypesMapping");
+        Map<String, Set<String>> contentTypesMapping =
+                (Map<String, Set<String>>) PrivateAccessor.getField(contentDispositionFilter, "contentTypesMapping");
         Assert.assertEquals(0, contentTypesMapping.size());
     }
 
     @SuppressWarnings("unchecked")
     @Test
-    public void test_activator2() throws Throwable{
-        callActivateWithConfiguration(new String[]{"/content/usergenerated/*"}, new String []{""});
-        Set<String> contentDispositionPaths = ( Set<String> ) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionPaths");
+    public void test_activator2() throws Throwable {
+        callActivateWithConfiguration(new String[] {"/content/usergenerated/*"}, new String[] {""});
+        Set<String> contentDispositionPaths =
+                (Set<String>) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionPaths");
         Assert.assertEquals(0, contentDispositionPaths.size());
-        String[] contentDispositionPathsPfx = ( String[] ) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionPathsPfx");
+        String[] contentDispositionPathsPfx =
+                (String[]) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionPathsPfx");
         Assert.assertEquals(1, contentDispositionPathsPfx.length);
-        Map <String, Set<String>> contentTypesMapping = ( Map <String, Set<String>> ) PrivateAccessor.getField(contentDispositionFilter, "contentTypesMapping");
+        Map<String, Set<String>> contentTypesMapping =
+                (Map<String, Set<String>>) PrivateAccessor.getField(contentDispositionFilter, "contentTypesMapping");
         Assert.assertEquals(0, contentTypesMapping.size());
     }
 
     @SuppressWarnings("unchecked")
     @Test
-    public void test_activator3() throws Throwable{
-        callActivateWithConfiguration(new String[]{"/libs", "/content/usergenerated/*"}, new String[]{""});
-        Set<String> contentDispositionPaths = ( Set<String> ) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionPaths");
+    public void test_activator3() throws Throwable {
+        callActivateWithConfiguration(new String[] {"/libs", "/content/usergenerated/*"}, new String[] {""});
+        Set<String> contentDispositionPaths =
+                (Set<String>) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionPaths");
         Assert.assertEquals(1, contentDispositionPaths.size());
-        String[] contentDispositionPathsPfx = ( String[] ) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionPathsPfx");
+        String[] contentDispositionPathsPfx =
+                (String[]) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionPathsPfx");
         Assert.assertEquals(1, contentDispositionPathsPfx.length);
-        Map <String, Set<String>> contentTypesMapping = ( Map <String, Set<String>> ) PrivateAccessor.getField(contentDispositionFilter, "contentTypesMapping");
+        Map<String, Set<String>> contentTypesMapping =
+                (Map<String, Set<String>>) PrivateAccessor.getField(contentDispositionFilter, "contentTypesMapping");
         Assert.assertEquals(0, contentTypesMapping.size());
     }
 
     @SuppressWarnings("unchecked")
     @Test
-    public void test_activator5() throws Throwable{
-        callActivateWithConfiguration(new String[]{"*"}, new String[]{""});
-        Set<String> contentDispositionPaths = ( Set<String> ) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionPaths");
+    public void test_activator5() throws Throwable {
+        callActivateWithConfiguration(new String[] {"*"}, new String[] {""});
+        Set<String> contentDispositionPaths =
+                (Set<String>) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionPaths");
         Assert.assertEquals(0, contentDispositionPaths.size());
-        String[] contentDispositionPathsPfx = ( String[] ) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionPathsPfx");
+        String[] contentDispositionPathsPfx =
+                (String[]) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionPathsPfx");
         Assert.assertEquals(0, contentDispositionPathsPfx.length);
-        Map <String, Set<String>> contentTypesMapping = ( Map <String, Set<String>> ) PrivateAccessor.getField(contentDispositionFilter, "contentTypesMapping");
+        Map<String, Set<String>> contentTypesMapping =
+                (Map<String, Set<String>>) PrivateAccessor.getField(contentDispositionFilter, "contentTypesMapping");
         Assert.assertEquals(0, contentTypesMapping.size());
     }
 
     @SuppressWarnings("unchecked")
     @Test
-    public void test_activator6() throws Throwable{
-        callActivateWithConfiguration(new String[]{"/libs:*"}, new String[]{""});
-        Set<String> contentDispositionPaths = ( Set<String> ) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionPaths");
+    public void test_activator6() throws Throwable {
+        callActivateWithConfiguration(new String[] {"/libs:*"}, new String[] {""});
+        Set<String> contentDispositionPaths =
+                (Set<String>) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionPaths");
         Assert.assertEquals(0, contentDispositionPaths.size());
-        String[] contentDispositionPathsPfx = ( String[] ) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionPathsPfx");
+        String[] contentDispositionPathsPfx =
+                (String[]) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionPathsPfx");
         Assert.assertEquals(0, contentDispositionPathsPfx.length);
-        Map <String, Set<String>> contentTypesMapping = ( Map <String, Set<String>> ) PrivateAccessor.getField(contentDispositionFilter, "contentTypesMapping");
+        Map<String, Set<String>> contentTypesMapping =
+                (Map<String, Set<String>>) PrivateAccessor.getField(contentDispositionFilter, "contentTypesMapping");
         Assert.assertEquals(0, contentTypesMapping.size());
     }
 
     @SuppressWarnings("unchecked")
     @Test
-    public void test_activator7() throws Throwable{
-        callActivateWithConfiguration(new String[]{"/libs:text/html,text/plain","/content/usergenerated/*:image/jpeg"}, new String[]{""});
-        Set<String> contentDispositionPaths = ( Set<String> ) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionPaths");
+    public void test_activator7() throws Throwable {
+        callActivateWithConfiguration(
+                new String[] {"/libs:text/html,text/plain", "/content/usergenerated/*:image/jpeg"}, new String[] {""});
+        Set<String> contentDispositionPaths =
+                (Set<String>) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionPaths");
         Assert.assertEquals(1, contentDispositionPaths.size());
-        String[] contentDispositionPathsPfx = ( String[] ) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionPathsPfx");
+        String[] contentDispositionPathsPfx =
+                (String[]) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionPathsPfx");
         Assert.assertEquals(1, contentDispositionPathsPfx.length);
-        Map <String, Set<String>> contentTypesMapping = ( Map <String, Set<String>> ) PrivateAccessor.getField(contentDispositionFilter, "contentTypesMapping");
+        Map<String, Set<String>> contentTypesMapping =
+                (Map<String, Set<String>>) PrivateAccessor.getField(contentDispositionFilter, "contentTypesMapping");
         Assert.assertEquals(2, contentTypesMapping.size());
         Set<String> libsMapping = contentTypesMapping.get("/libs");
         Assert.assertEquals(2, libsMapping.size());
@@ -169,51 +190,64 @@ public class ContentDispositionFilterTest {
         Set<String> userGeneratedMapping = contentTypesMapping.get("/content/usergenerated/");
         Assert.assertEquals(1, userGeneratedMapping.size());
         userGeneratedMapping.contains("image/jpeg");
-     }
+    }
 
-	@SuppressWarnings("unchecked")
+    @SuppressWarnings("unchecked")
     @Test
-    public void test_activator8() throws Throwable{
-        callActivateWithConfiguration(new String[]{"/libs:text/html,text/plain","/content/usergenerated/*:image/jpeg"}, new String[]{});
-        
-        Set<String> contentDispositionExcludedPaths = ( Set<String> ) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionExcludedPaths");
+    public void test_activator8() throws Throwable {
+        callActivateWithConfiguration(
+                new String[] {"/libs:text/html,text/plain", "/content/usergenerated/*:image/jpeg"}, new String[] {});
+
+        Set<String> contentDispositionExcludedPaths =
+                (Set<String>) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionExcludedPaths");
         Assert.assertEquals(0, contentDispositionExcludedPaths.size());
     }
-     
+
     @SuppressWarnings("unchecked")
     @Test
-    public void test_activator9() throws Throwable{
-        callActivateWithConfiguration(new String[]{"/libs:text/html,text/plain","/content/usergenerated/*:image/jpeg"}, new String[]{"/content", "/libs"});
+    public void test_activator9() throws Throwable {
+        callActivateWithConfiguration(
+                new String[] {"/libs:text/html,text/plain", "/content/usergenerated/*:image/jpeg"},
+                new String[] {"/content", "/libs"});
 
-        Set<String> contentDispositionExcludedPaths = ( Set<String> ) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionExcludedPaths");
+        Set<String> contentDispositionExcludedPaths =
+                (Set<String>) PrivateAccessor.getField(contentDispositionFilter, "contentDispositionExcludedPaths");
         Assert.assertEquals(2, contentDispositionExcludedPaths.size());
-     }
+    }
 
     @SuppressWarnings("unchecked")
     @Test
-    public void test_getContentTypes() throws Throwable{
+    public void test_getContentTypes() throws Throwable {
         // null content types
         String contentType = null;
-        Set <String> contentTypesSet = ( Set <String>) PrivateAccessor.invoke(ContentDispositionFilter.class,"getContentTypes",  new Class[]{String.class},new Object[]{contentType});
+        Set<String> contentTypesSet = (Set<String>) PrivateAccessor.invoke(
+                ContentDispositionFilter.class, "getContentTypes", new Class[] {String.class}, new Object[] {contentType
+                });
         Assert.assertEquals(0, contentTypesSet.size());
         // empty content types
         contentType = "";
-        contentTypesSet = ( Set <String>) PrivateAccessor.invoke(ContentDispositionFilter.class,"getContentTypes",  new Class[]{String.class},new Object[]{contentType});
+        contentTypesSet = (Set<String>) PrivateAccessor.invoke(
+                ContentDispositionFilter.class, "getContentTypes", new Class[] {String.class}, new Object[] {contentType
+                });
         Assert.assertEquals(0, contentTypesSet.size());
         contentType = "text/html";
-        contentTypesSet = ( Set <String>) PrivateAccessor.invoke(ContentDispositionFilter.class,"getContentTypes",  new Class[]{String.class},new Object[]{contentType});
+        contentTypesSet = (Set<String>) PrivateAccessor.invoke(
+                ContentDispositionFilter.class, "getContentTypes", new Class[] {String.class}, new Object[] {contentType
+                });
         Assert.assertEquals(1, contentTypesSet.size());
         contentType = "text/html,text/plain";
-        contentTypesSet = ( Set <String>) PrivateAccessor.invoke(ContentDispositionFilter.class,"getContentTypes",  new Class[]{String.class},new Object[]{contentType});
+        contentTypesSet = (Set<String>) PrivateAccessor.invoke(
+                ContentDispositionFilter.class, "getContentTypes", new Class[] {String.class}, new Object[] {contentType
+                });
         Assert.assertEquals(2, contentTypesSet.size());
     }
 
     @Test
-    public void test_doFilter1() throws Throwable{
+    public void test_doFilter1() throws Throwable {
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
-        final Resource resource = context.mock(Resource.class, "resource" );
-        callActivateWithConfiguration(new String[]{"/content/usergenerated"}, new String[]{""});
+        final Resource resource = context.mock(Resource.class, "resource");
+        callActivateWithConfiguration(new String[] {"/content/usergenerated"}, new String[] {""});
 
         context.checking(new Expectations() {
             {
@@ -227,22 +261,22 @@ public class ContentDispositionFilterTest {
                 allowing(resource).getPath();
                 will(returnValue("/libs"));
                 allowing(response).setContentType("text/html");
-                //CONTENT DISPOSITION MUST NOT SET
+                // CONTENT DISPOSITION MUST NOT SET
                 never(response).addHeader("Content-Disposition", "attachment");
-
             }
         });
-        ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response);
+        ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response);
 
         rewriterResponse.setContentType("text/html");
     }
 
     @Test
-    public void test_doFilter2() throws Throwable{
+    public void test_doFilter2() throws Throwable {
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
-        final Resource resource = context.mock(Resource.class, "resource" );
-        callActivateWithConfiguration(new String[]{"/content/usergenerated"}, new String[]{""});
+        final Resource resource = context.mock(Resource.class, "resource");
+        callActivateWithConfiguration(new String[] {"/content/usergenerated"}, new String[] {""});
 
         context.checking(new Expectations() {
             {
@@ -256,24 +290,25 @@ public class ContentDispositionFilterTest {
                 allowing(resource).getPath();
                 will(returnValue("/content/usergenerated/author"));
                 allowing(response).setContentType("text/html");
-                //CONTENT DISPOSITION MUST NOT SET
+                // CONTENT DISPOSITION MUST NOT SET
                 never(response).addHeader("Content-Disposition", "attachment");
             }
         });
-        ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response);
+        ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response);
 
         rewriterResponse.setContentType("text/html");
     }
 
     @Test
-    public void test_doFilter3() throws Throwable{
+    public void test_doFilter3() throws Throwable {
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
-        final Resource resource = context.mock(Resource.class, "resource" );
+        final Resource resource = context.mock(Resource.class, "resource");
         final ValueMap properties = context.mock(ValueMap.class);
-		callActivateWithConfiguration(new String[]{"/content/usergenerated"}, new String[]{""});
+        callActivateWithConfiguration(new String[] {"/content/usergenerated"}, new String[] {""});
 
-        final AtomicInteger counter =  new AtomicInteger();
+        final AtomicInteger counter = new AtomicInteger();
 
         context.checking(new Expectations() {
             {
@@ -293,26 +328,27 @@ public class ContentDispositionFilterTest {
                 allowing(properties).containsKey(PROP_JCR_DATA);
                 will(returnValue(true));
                 allowing(response).setContentType("text/html");
-                //CONTENT DISPOSITION IS SET
+                // CONTENT DISPOSITION IS SET
                 exactly(1).of(response).addHeader("Content-Disposition", "attachment");
             }
         });
-        final ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response) {
-            @Override
-            public void addHeader(String name, String value) {
-                counter.incrementAndGet();
-            }
-        };
+        final ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response) {
+                    @Override
+                    public void addHeader(String name, String value) {
+                        counter.incrementAndGet();
+                    }
+                };
         rewriterResponse.setContentType("text/html");
         Assert.assertEquals(1, counter.intValue());
     }
 
     @Test
-    public void test_doFilter4() throws Throwable{
+    public void test_doFilter4() throws Throwable {
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
-        final Resource resource = context.mock(Resource.class, "resource" );
-        callActivateWithConfiguration(new String[]{"/content/usergenerated/*"}, new String[]{""});
+        final Resource resource = context.mock(Resource.class, "resource");
+        callActivateWithConfiguration(new String[] {"/content/usergenerated/*"}, new String[] {""});
 
         context.checking(new Expectations() {
             {
@@ -326,24 +362,24 @@ public class ContentDispositionFilterTest {
                 allowing(resource).getPath();
                 will(returnValue("/libs"));
                 allowing(response).setContentType("text/html");
-                //CONTENT DISPOSITION MUST NOT SET
+                // CONTENT DISPOSITION MUST NOT SET
                 never(response).addHeader("Content-Disposition", "attachment");
-
             }
         });
-        ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response);
+        ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response);
         rewriterResponse.setContentType("text/html");
     }
 
     @Test
-    public void test_doFilter5() throws Throwable{
+    public void test_doFilter5() throws Throwable {
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
-        final Resource resource = context.mock(Resource.class, "resource" );
+        final Resource resource = context.mock(Resource.class, "resource");
         final ValueMap properties = context.mock(ValueMap.class);
-        callActivateWithConfiguration(new String[]{"/content/usergenerated/*"}, new String[]{""});
+        callActivateWithConfiguration(new String[] {"/content/usergenerated/*"}, new String[] {""});
 
-        final AtomicInteger counter =  new AtomicInteger();
+        final AtomicInteger counter = new AtomicInteger();
 
         context.checking(new Expectations() {
             {
@@ -363,29 +399,30 @@ public class ContentDispositionFilterTest {
                 allowing(properties).containsKey(PROP_JCR_DATA);
                 will(returnValue(true));
                 allowing(response).setContentType("text/html");
-                //CONTENT DISPOSITION IS SET
+                // CONTENT DISPOSITION IS SET
                 exactly(1).of(response).addHeader("Content-Disposition", "attachment");
             }
         });
-        final ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response) {
-            @Override
-            public void addHeader(String name, String value) {
-                counter.incrementAndGet();
-            }
-        };
+        final ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response) {
+                    @Override
+                    public void addHeader(String name, String value) {
+                        counter.incrementAndGet();
+                    }
+                };
         rewriterResponse.setContentType("text/html");
         Assert.assertEquals(1, counter.intValue());
     }
 
     @Test
-    public void test_doFilter6() throws Throwable{
+    public void test_doFilter6() throws Throwable {
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
-        final Resource resource = context.mock(Resource.class, "resource" );
+        final Resource resource = context.mock(Resource.class, "resource");
         final ValueMap properties = context.mock(ValueMap.class);
-        callActivateWithConfiguration(new String[]{"/content/usergenerated/*"}, new String[]{""});
+        callActivateWithConfiguration(new String[] {"/content/usergenerated/*"}, new String[] {""});
 
-        final AtomicInteger counter =  new AtomicInteger();
+        final AtomicInteger counter = new AtomicInteger();
 
         context.checking(new Expectations() {
             {
@@ -405,26 +442,27 @@ public class ContentDispositionFilterTest {
                 allowing(properties).containsKey(PROP_JCR_DATA);
                 will(returnValue(true));
                 allowing(response).setContentType("text/html");
-                //CONTENT DISPOSITION IS SET
+                // CONTENT DISPOSITION IS SET
                 exactly(1).of(response).addHeader("Content-Disposition", "attachment");
             }
         });
-        final ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response) {
-            @Override
-            public void addHeader(String name, String value) {
-                counter.incrementAndGet();
-            }
-        };
+        final ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response) {
+                    @Override
+                    public void addHeader(String name, String value) {
+                        counter.incrementAndGet();
+                    }
+                };
         rewriterResponse.setContentType("text/html");
         Assert.assertEquals(1, counter.intValue());
     }
 
     @Test
-    public void test_doFilter7() throws Throwable{
+    public void test_doFilter7() throws Throwable {
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
-        final Resource resource = context.mock(Resource.class, "resource" );
-        callActivateWithConfiguration(new String[]{"/content/usergenerated:text/html,text/plain"}, new String[]{""});
+        final Resource resource = context.mock(Resource.class, "resource");
+        callActivateWithConfiguration(new String[] {"/content/usergenerated:text/html,text/plain"}, new String[] {""});
 
         context.checking(new Expectations() {
             {
@@ -438,22 +476,22 @@ public class ContentDispositionFilterTest {
                 allowing(resource).getPath();
                 will(returnValue("/libs"));
                 allowing(response).setContentType("text/html");
-                //CONTENT DISPOSITION MUST NOT SET
+                // CONTENT DISPOSITION MUST NOT SET
                 never(response).addHeader("Content-Disposition", "attachment");
-
             }
         });
-        ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response);
+        ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response);
 
         rewriterResponse.setContentType("text/html");
     }
 
     @Test
-    public void test_doFilter8() throws Throwable{
+    public void test_doFilter8() throws Throwable {
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
-        final Resource resource = context.mock(Resource.class, "resource" );
-        callActivateWithConfiguration(new String[]{"/content/usergenerated:text/html,text/plain"}, new String[]{""});
+        final Resource resource = context.mock(Resource.class, "resource");
+        callActivateWithConfiguration(new String[] {"/content/usergenerated:text/html,text/plain"}, new String[] {""});
 
         context.checking(new Expectations() {
             {
@@ -467,21 +505,22 @@ public class ContentDispositionFilterTest {
                 allowing(resource).getPath();
                 will(returnValue("/content/usergenerated/author"));
                 allowing(response).setContentType("text/html");
-                //CONTENT DISPOSITION MUST NOT SET
+                // CONTENT DISPOSITION MUST NOT SET
                 never(response).addHeader("Content-Disposition", "attachment");
             }
         });
-        ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response);
+        ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response);
 
         rewriterResponse.setContentType("text/html");
     }
 
     @Test
-    public void test_doFilter9() throws Throwable{
+    public void test_doFilter9() throws Throwable {
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
-        final Resource resource = context.mock(Resource.class, "resource" );
-        callActivateWithConfiguration(new String[]{"/content/usergenerated:text/html,text/plain"}, new String[]{""});
+        final Resource resource = context.mock(Resource.class, "resource");
+        callActivateWithConfiguration(new String[] {"/content/usergenerated:text/html,text/plain"}, new String[] {""});
 
         context.checking(new Expectations() {
             {
@@ -495,25 +534,26 @@ public class ContentDispositionFilterTest {
                 allowing(resource).getPath();
                 will(returnValue("/content/usergenerated"));
                 allowing(response).setContentType("text/html");
-                //CONTENT DISPOSITION MUST NOT SET
+                // CONTENT DISPOSITION MUST NOT SET
                 never(response).addHeader("Content-Disposition", "attachment");
             }
         });
-        ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response);
+        ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response);
 
         rewriterResponse.setContentType("text/html");
     }
 
     @Test
-    public void test_doFilter10() throws Throwable{
+    public void test_doFilter10() throws Throwable {
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
-        final Resource resource = context.mock(Resource.class, "resource" );
+        final Resource resource = context.mock(Resource.class, "resource");
         final ValueMap properties = context.mock(ValueMap.class);
 
-        callActivateWithConfiguration(new String[]{"/content/usergenerated:text/html,text/plain"}, new String[]{""});
+        callActivateWithConfiguration(new String[] {"/content/usergenerated:text/html,text/plain"}, new String[] {""});
 
-        final AtomicInteger counter =  new AtomicInteger();
+        final AtomicInteger counter = new AtomicInteger();
 
         context.checking(new Expectations() {
             {
@@ -533,26 +573,28 @@ public class ContentDispositionFilterTest {
                 allowing(properties).containsKey(PROP_JCR_DATA);
                 will(returnValue(true));
                 allowing(response).setContentType("image/jpeg");
-                //CONTENT DISPOSITION IS SET
+                // CONTENT DISPOSITION IS SET
                 exactly(1).of(response).addHeader("Content-Disposition", "attachment");
             }
         });
-        final ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response) {
-            @Override
-            public void addHeader(String name, String value) {
-                counter.incrementAndGet();
-            }
-        };
+        final ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response) {
+                    @Override
+                    public void addHeader(String name, String value) {
+                        counter.incrementAndGet();
+                    }
+                };
         rewriterResponse.setContentType("image/jpeg");
         Assert.assertEquals(1, counter.intValue());
     }
 
     @Test
-    public void test_doFilter11() throws Throwable{
+    public void test_doFilter11() throws Throwable {
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
-        final Resource resource = context.mock(Resource.class, "resource" );
-        callActivateWithConfiguration(new String[]{"/content/usergenerated/*:text/html,text/plain"}, new String[]{""});
+        final Resource resource = context.mock(Resource.class, "resource");
+        callActivateWithConfiguration(
+                new String[] {"/content/usergenerated/*:text/html,text/plain"}, new String[] {""});
 
         context.checking(new Expectations() {
             {
@@ -566,22 +608,23 @@ public class ContentDispositionFilterTest {
                 allowing(resource).getPath();
                 will(returnValue("/libs"));
                 allowing(response).setContentType("text/html");
-                //CONTENT DISPOSITION MUST NOT SET
+                // CONTENT DISPOSITION MUST NOT SET
                 never(response).addHeader("Content-Disposition", "attachment");
-
             }
         });
-        ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response);
+        ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response);
 
         rewriterResponse.setContentType("text/html");
     }
 
     @Test
-    public void test_doFilter12() throws Throwable{
+    public void test_doFilter12() throws Throwable {
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
-        final Resource resource = context.mock(Resource.class, "resource" );
-        callActivateWithConfiguration(new String[]{"/content/usergenerated/*:text/html,text/plain"}, new String[]{""});
+        final Resource resource = context.mock(Resource.class, "resource");
+        callActivateWithConfiguration(
+                new String[] {"/content/usergenerated/*:text/html,text/plain"}, new String[] {""});
 
         context.checking(new Expectations() {
             {
@@ -595,21 +638,23 @@ public class ContentDispositionFilterTest {
                 allowing(resource).getPath();
                 will(returnValue("/content/usergenerated/author"));
                 allowing(response).setContentType("text/html");
-                //CONTENT DISPOSITION MUST NOT SET
+                // CONTENT DISPOSITION MUST NOT SET
                 never(response).addHeader("Content-Disposition", "attachment");
             }
         });
-        ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response);
+        ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response);
 
         rewriterResponse.setContentType("text/html");
     }
 
     @Test
-    public void test_doFilter13() throws Throwable{
+    public void test_doFilter13() throws Throwable {
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
-        final Resource resource = context.mock(Resource.class, "resource" );
-        callActivateWithConfiguration(new String[]{"/content/usergenerated/*:text/html,text/plain"}, new String[]{""});
+        final Resource resource = context.mock(Resource.class, "resource");
+        callActivateWithConfiguration(
+                new String[] {"/content/usergenerated/*:text/html,text/plain"}, new String[] {""});
 
         context.checking(new Expectations() {
             {
@@ -623,24 +668,26 @@ public class ContentDispositionFilterTest {
                 allowing(resource).getPath();
                 will(returnValue("/content/usergenerated/author"));
                 allowing(response).setContentType("text/html");
-                //CONTENT DISPOSITION MUST NOT SET
+                // CONTENT DISPOSITION MUST NOT SET
                 never(response).addHeader("Content-Disposition", "attachment");
             }
         });
-        ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response);
+        ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response);
 
         rewriterResponse.setContentType("text/html");
     }
 
     @Test
-    public void test_doFilter14() throws Throwable{
+    public void test_doFilter14() throws Throwable {
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
-        final Resource resource = context.mock(Resource.class, "resource" );
+        final Resource resource = context.mock(Resource.class, "resource");
         final ValueMap properties = context.mock(ValueMap.class);
-        callActivateWithConfiguration(new String[]{"/content/usergenerated/*:text/html,text/plain"}, new String[]{""});
+        callActivateWithConfiguration(
+                new String[] {"/content/usergenerated/*:text/html,text/plain"}, new String[] {""});
 
-        final AtomicInteger counter =  new AtomicInteger();
+        final AtomicInteger counter = new AtomicInteger();
 
         context.checking(new Expectations() {
             {
@@ -660,16 +707,17 @@ public class ContentDispositionFilterTest {
                 allowing(properties).containsKey(PROP_JCR_DATA);
                 will(returnValue(true));
                 allowing(response).setContentType("image/jpeg");
-                //CONTENT DISPOSITION IS SET
+                // CONTENT DISPOSITION IS SET
                 exactly(1).of(response).addHeader("Content-Disposition", "attachment");
             }
         });
-        final ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response) {
-            @Override
-            public void addHeader(String name, String value) {
-                counter.incrementAndGet();
-            }
-        };
+        final ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response) {
+                    @Override
+                    public void addHeader(String name, String value) {
+                        counter.incrementAndGet();
+                    }
+                };
         rewriterResponse.setContentType("image/jpeg");
         Assert.assertEquals(1, counter.intValue());
     }
@@ -679,14 +727,14 @@ public class ContentDispositionFilterTest {
      * @throws Throwable
      */
     @Test
-    public void test_doFilter15() throws Throwable{
+    public void test_doFilter15() throws Throwable {
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
-        final Resource resource = context.mock(Resource.class, "resource" );
+        final Resource resource = context.mock(Resource.class, "resource");
         final ValueMap properties = context.mock(ValueMap.class);
-        callActivateWithConfiguration(new String[]{"/content/usergenerated"}, new String[]{""});
+        callActivateWithConfiguration(new String[] {"/content/usergenerated"}, new String[] {""});
 
-        final AtomicInteger counter =  new AtomicInteger();
+        final AtomicInteger counter = new AtomicInteger();
 
         context.checking(new Expectations() {
             {
@@ -708,16 +756,17 @@ public class ContentDispositionFilterTest {
                 allowing(properties).containsKey(PROP_JCR_DATA);
                 will(returnValue(true));
                 allowing(response).setContentType("text/html");
-                //CONTENT DISPOSITION IS SET
+                // CONTENT DISPOSITION IS SET
                 exactly(1).of(response).addHeader("Content-Disposition", "attachment");
             }
         });
-        final ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response) {
-            @Override
-            public void addHeader(String name, String value) {
-                counter.incrementAndGet();
-            }
-        };
+        final ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response) {
+                    @Override
+                    public void addHeader(String name, String value) {
+                        counter.incrementAndGet();
+                    }
+                };
         rewriterResponse.setContentType("text/html");
         rewriterResponse.setContentType("text/html");
         Assert.assertEquals(1, counter.intValue());
@@ -728,14 +777,14 @@ public class ContentDispositionFilterTest {
      * @throws Throwable
      */
     @Test
-    public void test_doFilter16() throws Throwable{
+    public void test_doFilter16() throws Throwable {
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
-        final Resource resource = context.mock(Resource.class, "resource" );
+        final Resource resource = context.mock(Resource.class, "resource");
         final ValueMap properties = context.mock(ValueMap.class);
-        callActivateWithConfiguration(new String[]{"/content/usergenerated"}, new String[]{""});
+        callActivateWithConfiguration(new String[] {"/content/usergenerated"}, new String[] {""});
 
-        final AtomicInteger counter =  new AtomicInteger();
+        final AtomicInteger counter = new AtomicInteger();
 
         context.checking(new Expectations() {
             {
@@ -761,32 +810,32 @@ public class ContentDispositionFilterTest {
                 will(returnValue(true));
                 allowing(response).setContentType("text/html");
                 allowing(response).setContentType("text/xml");
-                //CONTENT DISPOSITION IS SET
+                // CONTENT DISPOSITION IS SET
                 exactly(1).of(response).addHeader("Content-Disposition", "attachment");
             }
         });
-        final ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response) {
-            @Override
-            public void addHeader(String name, String value) {
-                counter.incrementAndGet();
-            }
-        };
+        final ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response) {
+                    @Override
+                    public void addHeader(String name, String value) {
+                        counter.incrementAndGet();
+                    }
+                };
         rewriterResponse.setContentType("text/html");
         rewriterResponse.setContentType("text/xml");
         Assert.assertEquals(1, counter.intValue());
     }
 
-
     @Test
-    public void test_doFilter17() throws Throwable{
+    public void test_doFilter17() throws Throwable {
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
-        final Resource resource = context.mock(Resource.class, "resource" );
+        final Resource resource = context.mock(Resource.class, "resource");
         final ValueMap properties = context.mock(ValueMap.class);
 
-        callActivateWithConfiguration(new String[]{"/content/usergenerated"}, new String[]{""}, false);
+        callActivateWithConfiguration(new String[] {"/content/usergenerated"}, new String[] {""}, false);
 
-        final AtomicInteger counter =  new AtomicInteger();
+        final AtomicInteger counter = new AtomicInteger();
 
         context.checking(new Expectations() {
             {
@@ -812,29 +861,30 @@ public class ContentDispositionFilterTest {
                 will(returnValue(true));
                 allowing(response).setContentType("text/html");
                 allowing(response).setContentType("text/xml");
-                //CONTENT DISPOSITION IS NOT SET
+                // CONTENT DISPOSITION IS NOT SET
                 never(response).addHeader("Content-Disposition", "attachment");
             }
         });
-        final ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response) {
-            @Override
-            public void addHeader(String name, String value) {
-                counter.incrementAndGet();
-            }
-        };
+        final ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response) {
+                    @Override
+                    public void addHeader(String name, String value) {
+                        counter.incrementAndGet();
+                    }
+                };
         rewriterResponse.setContentType("text/html");
         Assert.assertEquals(0, counter.intValue());
     }
 
     @Test
-    public void test_doFilter18() throws Throwable{
+    public void test_doFilter18() throws Throwable {
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
-        final Resource resource = context.mock(Resource.class, "resource" );
+        final Resource resource = context.mock(Resource.class, "resource");
         final ValueMap properties = context.mock(ValueMap.class);
-        callActivateWithConfiguration(new String[]{"/content/usergenerated"}, new String[]{""}, true);
+        callActivateWithConfiguration(new String[] {"/content/usergenerated"}, new String[] {""}, true);
 
-        final AtomicInteger counter =  new AtomicInteger();
+        final AtomicInteger counter = new AtomicInteger();
 
         context.checking(new Expectations() {
             {
@@ -860,29 +910,30 @@ public class ContentDispositionFilterTest {
                 will(returnValue(true));
                 allowing(response).setContentType("text/html");
                 allowing(response).setContentType("text/xml");
-                //CONTENT DISPOSITION IS SET
+                // CONTENT DISPOSITION IS SET
                 exactly(1).of(response).addHeader("Content-Disposition", "attachment");
             }
         });
-        final ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response) {
-            @Override
-            public void addHeader(String name, String value) {
-                counter.incrementAndGet();
-            }
-        };
+        final ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response) {
+                    @Override
+                    public void addHeader(String name, String value) {
+                        counter.incrementAndGet();
+                    }
+                };
         rewriterResponse.setContentType("text/html");
         Assert.assertEquals(1, counter.intValue());
     }
 
     @Test
-    public void test_doFilter19() throws Throwable{
+    public void test_doFilter19() throws Throwable {
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
-        final Resource resource = context.mock(Resource.class, "resource" );
+        final Resource resource = context.mock(Resource.class, "resource");
         final ValueMap properties = context.mock(ValueMap.class);
-        callActivateWithConfiguration(new String[]{"/content/usergenerated"}, new String[]{"/content"}, true);
+        callActivateWithConfiguration(new String[] {"/content/usergenerated"}, new String[] {"/content"}, true);
 
-        final AtomicInteger counter =  new AtomicInteger();
+        final AtomicInteger counter = new AtomicInteger();
 
         context.checking(new Expectations() {
             {
@@ -908,29 +959,30 @@ public class ContentDispositionFilterTest {
                 will(returnValue(true));
                 allowing(response).setContentType("text/html");
                 allowing(response).setContentType("text/xml");
-                //CONTENT DISPOSITION IS SET
+                // CONTENT DISPOSITION IS SET
                 exactly(1).of(response).addHeader("Content-Disposition", "attachment");
             }
         });
-        final ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response) {
-            @Override
-            public void addHeader(String name, String value) {
-                counter.incrementAndGet();
-            }
-        };
+        final ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response) {
+                    @Override
+                    public void addHeader(String name, String value) {
+                        counter.incrementAndGet();
+                    }
+                };
         rewriterResponse.setContentType("text/html");
         Assert.assertEquals(1, counter.intValue());
     }
 
     @Test
-    public void test_doFilter20() throws Throwable{
+    public void test_doFilter20() throws Throwable {
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
-        final Resource resource = context.mock(Resource.class, "resource" );
+        final Resource resource = context.mock(Resource.class, "resource");
         final ValueMap properties = context.mock(ValueMap.class);
-        callActivateWithConfiguration(new String[]{"/content/usergenerated"}, new String[]{"/content/other"}, true);
+        callActivateWithConfiguration(new String[] {"/content/usergenerated"}, new String[] {"/content/other"}, true);
 
-        final AtomicInteger counter =  new AtomicInteger();
+        final AtomicInteger counter = new AtomicInteger();
 
         context.checking(new Expectations() {
             {
@@ -956,29 +1008,30 @@ public class ContentDispositionFilterTest {
                 will(returnValue(true));
                 allowing(response).setContentType("text/html");
                 allowing(response).setContentType("text/xml");
-                //CONTENT DISPOSITION IS NOT SET
+                // CONTENT DISPOSITION IS NOT SET
                 never(response).addHeader("Content-Disposition", "attachment");
             }
         });
-        final ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response) {
-            @Override
-            public void addHeader(String name, String value) {
-                counter.incrementAndGet();
-            }
-        };
+        final ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response) {
+                    @Override
+                    public void addHeader(String name, String value) {
+                        counter.incrementAndGet();
+                    }
+                };
         rewriterResponse.setContentType("text/html");
         Assert.assertEquals(0, counter.intValue());
     }
 
     @Test
-    public void test_doFilter21() throws Throwable{
+    public void test_doFilter21() throws Throwable {
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
-        final Resource resource = context.mock(Resource.class, "resource" );
+        final Resource resource = context.mock(Resource.class, "resource");
         final ValueMap properties = context.mock(ValueMap.class);
-        callActivateWithConfiguration(new String[]{"/content/usergenerated"}, new String[]{"/content"});
+        callActivateWithConfiguration(new String[] {"/content/usergenerated"}, new String[] {"/content"});
 
-        final AtomicInteger counter =  new AtomicInteger();
+        final AtomicInteger counter = new AtomicInteger();
 
         context.checking(new Expectations() {
             {
@@ -998,34 +1051,35 @@ public class ContentDispositionFilterTest {
                 allowing(properties).containsKey(PROP_JCR_DATA);
                 will(returnValue(true));
                 allowing(response).setContentType("text/html");
-                //CONTENT DISPOSITION IS SET
+                // CONTENT DISPOSITION IS SET
                 exactly(1).of(response).addHeader("Content-Disposition", "attachment");
             }
         });
-        final ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response) {
-            @Override
-            public void addHeader(String name, String value) {
-                counter.incrementAndGet();
-            }
-        };
+        final ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response) {
+                    @Override
+                    public void addHeader(String name, String value) {
+                        counter.incrementAndGet();
+                    }
+                };
         rewriterResponse.setContentType("text/html");
         Assert.assertEquals(1, counter.intValue());
     }
-    
+
     /**
      * Test multiple calls of setContentType which each result in a content-disposition header being needed.
      * Only one header should be added.
      * @throws Throwable
      */
     @Test
-    public void test_doFilter21b() throws Throwable{
+    public void test_doFilter21b() throws Throwable {
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
-        final Resource resource = context.mock(Resource.class, "resource" );
+        final Resource resource = context.mock(Resource.class, "resource");
         final ValueMap properties = context.mock(ValueMap.class);
-        callActivateWithConfiguration(new String[]{"/content/usergenerated"}, new String[]{"/content"});
+        callActivateWithConfiguration(new String[] {"/content/usergenerated"}, new String[] {"/content"});
 
-        final AtomicInteger counter =  new AtomicInteger();
+        final AtomicInteger counter = new AtomicInteger();
 
         context.checking(new Expectations() {
             {
@@ -1047,24 +1101,25 @@ public class ContentDispositionFilterTest {
                 will(returnValue(properties));
                 allowing(properties).containsKey(PROP_JCR_DATA);
                 will(returnValue(true));
-                
+
                 // Exactly 2 setContentType should reach the mock response.
                 exactly(1).of(response).setContentType("text/html");
                 exactly(1).of(response).setContentType("text/html");
-                //CONTENT DISPOSITION IS SET
+                // CONTENT DISPOSITION IS SET
                 exactly(1).of(response).addHeader("Content-Disposition", "attachment");
             }
         });
-        final ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response) {
-            @Override
-            public void addHeader(String name, String value) {
-                counter.incrementAndGet();
-            }
-        };
+        final ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response) {
+                    @Override
+                    public void addHeader(String name, String value) {
+                        counter.incrementAndGet();
+                    }
+                };
         rewriterResponse.setContentType("text/html");
         Assert.assertEquals(1, counter.intValue());
         rewriterResponse.reset();
-        
+
         /* Reset on the response clears all the headers, so if we setContentType again the content type header *and* the
          * content disposition should both reappear. The counter counts each time the content disposition header is added.
          * The setContentType calls on the mock response are enforced in the Expectations checked above.
@@ -1075,14 +1130,14 @@ public class ContentDispositionFilterTest {
     }
 
     @Test
-    public void test_doFilter22() throws Throwable{
+    public void test_doFilter22() throws Throwable {
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
-        final Resource resource = context.mock(Resource.class, "resource" );
+        final Resource resource = context.mock(Resource.class, "resource");
         final ValueMap properties = context.mock(ValueMap.class);
-        callActivateWithConfiguration(new String[]{"/content/usergenerated"}, new String[]{"/content/usergenerated"});
+        callActivateWithConfiguration(new String[] {"/content/usergenerated"}, new String[] {"/content/usergenerated"});
 
-        final AtomicInteger counter =  new AtomicInteger();
+        final AtomicInteger counter = new AtomicInteger();
         context.checking(new Expectations() {
             {
                 allowing(request).getMethod();
@@ -1101,30 +1156,31 @@ public class ContentDispositionFilterTest {
                 allowing(properties).containsKey(PROP_JCR_DATA);
                 will(returnValue(true));
                 allowing(response).setContentType("text/html");
-                //CONTENT DISPOSITION IS NOT SET
+                // CONTENT DISPOSITION IS NOT SET
                 never(response).addHeader("Content-Disposition", "attachment");
             }
         });
-        final ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response) {
-            @Override
-            public void addHeader(String name, String value) {
-                counter.incrementAndGet();
-            }
-        };
+        final ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response) {
+                    @Override
+                    public void addHeader(String name, String value) {
+                        counter.incrementAndGet();
+                    }
+                };
 
         rewriterResponse.setContentType("text/html");
         Assert.assertEquals(0, counter.intValue());
     }
-    
+
     @Test
-    public void test_doFilter22b() throws Throwable{
+    public void test_doFilter22b() throws Throwable {
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
-        final Resource resource = context.mock(Resource.class, "resource" );
+        final Resource resource = context.mock(Resource.class, "resource");
         final ValueMap properties = context.mock(ValueMap.class);
-        callActivateWithConfiguration(new String[]{"/content/usergenerated"}, new String[]{"/content/usergenerated"});
+        callActivateWithConfiguration(new String[] {"/content/usergenerated"}, new String[] {"/content/usergenerated"});
 
-        final AtomicInteger counter =  new AtomicInteger();
+        final AtomicInteger counter = new AtomicInteger();
         context.checking(new Expectations() {
             {
                 allowing(request).getMethod();
@@ -1145,25 +1201,27 @@ public class ContentDispositionFilterTest {
                 allowing(properties).containsKey(PROP_JCR_DATA);
                 will(returnValue(true));
                 exactly(2).of(response).setContentType("text/html");
-                //CONTENT DISPOSITION IS NOT SET
+                // CONTENT DISPOSITION IS NOT SET
                 never(response).addHeader("Content-Disposition", "attachment");
             }
         });
-        final ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response) {
-            @Override
-            public void addHeader(String name, String value) {
-                counter.incrementAndGet();
-            }
-        };
+        final ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response) {
+                    @Override
+                    public void addHeader(String name, String value) {
+                        counter.incrementAndGet();
+                    }
+                };
 
         rewriterResponse.setContentType("text/html");
         rewriterResponse.reset();
         rewriterResponse.setContentType("text/html");
         Assert.assertEquals(0, counter.intValue());
     }
+
     @Test
     public void test_isJcrData1() throws Throwable {
-        callActivateWithConfiguration(new String[]{"/content/usergenerated"}, new String[]{"/content/usergenerated"});
+        callActivateWithConfiguration(new String[] {"/content/usergenerated"}, new String[] {"/content/usergenerated"});
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
         final Resource resource = null;
@@ -1175,16 +1233,18 @@ public class ContentDispositionFilterTest {
             }
         });
 
-        final ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response);
+        final ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response);
 
-        Boolean result = (Boolean) PrivateAccessor.invoke(rewriterResponse,"isJcrData",  new Class[]{Resource.class},new Object[]{resource});
+        Boolean result = (Boolean) PrivateAccessor.invoke(
+                rewriterResponse, "isJcrData", new Class[] {Resource.class}, new Object[] {resource});
 
         Assert.assertFalse(result);
     }
 
     @Test
     public void test_isJcrData2() throws Throwable {
-        callActivateWithConfiguration(new String[]{"/content/usergenerated"}, new String[]{"/content/usergenerated"});
+        callActivateWithConfiguration(new String[] {"/content/usergenerated"}, new String[] {"/content/usergenerated"});
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
         final Resource resource = context.mock(Resource.class);
@@ -1196,7 +1256,8 @@ public class ContentDispositionFilterTest {
             }
         });
 
-        final ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response);
+        final ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response);
         final ValueMap properties = context.mock(ValueMap.class);
 
         context.checking(new Expectations() {
@@ -1208,14 +1269,15 @@ public class ContentDispositionFilterTest {
             }
         });
 
-        Boolean result = (Boolean) PrivateAccessor.invoke(rewriterResponse,"isJcrData",  new Class[]{Resource.class},new Object[]{resource});
+        Boolean result = (Boolean) PrivateAccessor.invoke(
+                rewriterResponse, "isJcrData", new Class[] {Resource.class}, new Object[] {resource});
 
         Assert.assertTrue(result);
     }
 
     @Test
     public void test_isJcrData3() throws Throwable {
-        callActivateWithConfiguration(new String[]{"/content/usergenerated"}, new String[]{"/content/usergenerated"});
+        callActivateWithConfiguration(new String[] {"/content/usergenerated"}, new String[] {"/content/usergenerated"});
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
 
@@ -1235,24 +1297,25 @@ public class ContentDispositionFilterTest {
             }
         });
 
-        final ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response);
+        final ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response);
 
-        Boolean result = (Boolean) PrivateAccessor.invoke(rewriterResponse,"isJcrData",  new Class[]{Resource.class},new Object[]{resource});
+        Boolean result = (Boolean) PrivateAccessor.invoke(
+                rewriterResponse, "isJcrData", new Class[] {Resource.class}, new Object[] {resource});
 
         Assert.assertFalse(result);
     }
 
     @Test
     public void test_isJcrData4() throws Throwable {
-        callActivateWithConfiguration(new String[]{"/content/usergenerated"}, new String[]{"/content/usergenerated"});
+        callActivateWithConfiguration(new String[] {"/content/usergenerated"}, new String[] {"/content/usergenerated"});
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
 
         final Resource child = context.mock(Resource.class, "child");
-        final Resource resource = context.mock(Resource.class, "resource" );
+        final Resource resource = context.mock(Resource.class, "resource");
         final ValueMap properties = context.mock(ValueMap.class);
         final ValueMap childPropoerties = context.mock(ValueMap.class, "childPropoerties");
-
 
         context.checking(new Expectations() {
             {
@@ -1271,23 +1334,24 @@ public class ContentDispositionFilterTest {
             }
         });
 
-        final ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response);
-        Boolean result = (Boolean) PrivateAccessor.invoke(rewriterResponse,"isJcrData",  new Class[]{Resource.class},new Object[]{resource});
+        final ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response);
+        Boolean result = (Boolean) PrivateAccessor.invoke(
+                rewriterResponse, "isJcrData", new Class[] {Resource.class}, new Object[] {resource});
 
         Assert.assertFalse(result);
     }
 
     @Test
     public void test_isJcrData5() throws Throwable {
-        callActivateWithConfiguration(new String[]{"/content/usergenerated"}, new String[]{"/content/usergenerated"});
+        callActivateWithConfiguration(new String[] {"/content/usergenerated"}, new String[] {"/content/usergenerated"});
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
 
         final Resource child = context.mock(Resource.class, "child");
-        final Resource resource = context.mock(Resource.class, "resource" );
+        final Resource resource = context.mock(Resource.class, "resource");
         final ValueMap properties = context.mock(ValueMap.class);
         final ValueMap childPropoerties = context.mock(ValueMap.class, "childPropoerties");
-
 
         context.checking(new Expectations() {
             {
@@ -1306,16 +1370,18 @@ public class ContentDispositionFilterTest {
             }
         });
 
-        final ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response);
+        final ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response);
 
-        Boolean result = (Boolean) PrivateAccessor.invoke(rewriterResponse,"isJcrData",  new Class[]{Resource.class},new Object[]{resource});
+        Boolean result = (Boolean) PrivateAccessor.invoke(
+                rewriterResponse, "isJcrData", new Class[] {Resource.class}, new Object[] {resource});
 
         Assert.assertTrue(result);
     }
 
     @Test
     public void test_isJcrData6() throws Throwable {
-        callActivateWithConfiguration(new String[]{"/content/usergenerated"}, new String[]{"/content/usergenerated"});
+        callActivateWithConfiguration(new String[] {"/content/usergenerated"}, new String[] {"/content/usergenerated"});
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
 
@@ -1331,23 +1397,23 @@ public class ContentDispositionFilterTest {
                 will(returnValue(null));
             }
         });
-        final ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response);
+        final ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response);
 
-        Boolean result = (Boolean) PrivateAccessor.invoke(rewriterResponse,"isJcrData",  new Class[]{Resource.class},new Object[]{resource});
+        Boolean result = (Boolean) PrivateAccessor.invoke(
+                rewriterResponse, "isJcrData", new Class[] {Resource.class}, new Object[] {resource});
 
         Assert.assertFalse(result);
     }
 
-
     @Test
     public void test_isJcrData7() throws Throwable {
-        callActivateWithConfiguration(new String[]{"/content/usergenerated"}, new String[]{"/content/usergenerated"});
+        callActivateWithConfiguration(new String[] {"/content/usergenerated"}, new String[] {"/content/usergenerated"});
         final SlingHttpServletRequest request = context.mock(SlingHttpServletRequest.class);
         final SlingHttpServletResponse response = context.mock(SlingHttpServletResponse.class);
         final Resource child = context.mock(Resource.class, "child");
-        final Resource resource = context.mock(Resource.class, "resource" );
+        final Resource resource = context.mock(Resource.class, "resource");
         final ValueMap properties = context.mock(ValueMap.class);
-
 
         context.checking(new Expectations() {
             {
@@ -1364,9 +1430,11 @@ public class ContentDispositionFilterTest {
             }
         });
 
-        final ContentDispositionFilter.RewriterResponse rewriterResponse = contentDispositionFilter. new RewriterResponse(request, response);
+        final ContentDispositionFilter.RewriterResponse rewriterResponse =
+                contentDispositionFilter.new RewriterResponse(request, response);
 
-        Boolean result = (Boolean) PrivateAccessor.invoke(rewriterResponse,"isJcrData",  new Class[]{Resource.class},new Object[]{resource});
+        Boolean result = (Boolean) PrivateAccessor.invoke(
+                rewriterResponse, "isJcrData", new Class[] {Resource.class}, new Object[] {resource});
 
         Assert.assertFalse(result);
     }

--- a/src/test/java/org/apache/sling/security/impl/ReferrerFilterTest.java
+++ b/src/test/java/org/apache/sling/security/impl/ReferrerFilterTest.java
@@ -1,35 +1,37 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.sling.security.impl;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import javax.servlet.http.HttpServletRequest;
 
 import java.lang.annotation.Annotation;
 import java.util.Collections;
-
-import javax.servlet.http.HttpServletRequest;
 
 import org.apache.sling.security.impl.ReferrerFilterAmendmentImpl.Config;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ReferrerFilterTest {
 
@@ -37,16 +39,21 @@ public class ReferrerFilterTest {
 
     @Before
     public void setup() {
-        ReferrerFilter.Config config = createConfiguration(false, new String[] { "relhost" },
-                new String[] { "http://([^.]*.)?abshost:80", "^app://.+" },
-                new String[] { "[a-zA-Z]*\\/[0-9]*\\.[0-9]*;Some-Agent\\s.*" },
-                new String[] { null, "/test_path" });
+        ReferrerFilter.Config config = createConfiguration(
+                false,
+                new String[] {"relhost"},
+                new String[] {"http://([^.]*.)?abshost:80", "^app://.+"},
+                new String[] {"[a-zA-Z]*\\/[0-9]*\\.[0-9]*;Some-Agent\\s.*"},
+                new String[] {null, "/test_path"});
         filter = new ReferrerFilter(config, Collections.emptyList());
     }
 
-    private static ReferrerFilter.Config createConfiguration(boolean allowEmpty, String[] allowHosts,
+    private static ReferrerFilter.Config createConfiguration(
+            boolean allowEmpty,
+            String[] allowHosts,
             String[] allowHostsRexexp,
-            String[] excludeAgentsRegexp, String[] excludePaths) {
+            String[] excludeAgentsRegexp,
+            String[] excludePaths) {
         return new ReferrerFilter.Config() {
             @Override
             public Class<? extends Annotation> annotationType() {
@@ -162,8 +169,8 @@ public class ReferrerFilterTest {
 
     @Test
     public void testExcludedPathNull() {
-        ReferrerFilter rf = new ReferrerFilter(createConfiguration(false, null, null, null, null),
-                Collections.emptyList());
+        ReferrerFilter rf =
+                new ReferrerFilter(createConfiguration(false, null, null, null, null), Collections.emptyList());
 
         assertFalse(rf.isValidRequest(getRequest(null, null, "/test_path")));
         assertFalse(rf.isValidRequest(getRequest(null, null, "/test_path/subtree")));
@@ -184,12 +191,12 @@ public class ReferrerFilterTest {
 
             @Override
             public String[] allow_hosts() {
-                return new String[]{"test.com"};
+                return new String[] {"test.com"};
             }
 
             @Override
             public String[] allow_hosts_regexp() {
-                return new String[]{".*test2.com.*"};
+                return new String[] {".*test2.com.*"};
             }
 
             @Override
@@ -199,12 +206,13 @@ public class ReferrerFilterTest {
 
             @Override
             public String[] exclude_paths() {
-                return new String[]{"/testpath2"};
+                return new String[] {"/testpath2"};
             }
-            
         });
-        ReferrerFilter rf = new ReferrerFilter(createConfiguration(false, null, new String[]{".*test1.com.*"}, null, null), Collections.singletonList(amendment));
-        
+        ReferrerFilter rf = new ReferrerFilter(
+                createConfiguration(false, null, new String[] {".*test1.com.*"}, null, null),
+                Collections.singletonList(amendment));
+
         assertTrue(rf.isValidRequest(getRequest(null, null, "/testpath2")));
         assertFalse(rf.isValidRequest(getRequest(null, null, "/test1path")));
 
@@ -213,9 +221,8 @@ public class ReferrerFilterTest {
         assertTrue(rf.isValidRequest(getRequest("http://test2.com:80", null, "/test_path")));
     }
 
-
     @Test
-    public void testAllowsWithOrigin(){
+    public void testAllowsWithOrigin() {
         HttpServletRequest request = getRequest(null);
         when(request.getHeader("origin")).thenReturn("http://abshost");
         Assert.assertEquals(true, filter.isValidRequest(request));
@@ -223,8 +230,8 @@ public class ReferrerFilterTest {
 
     @Test
     public void testAllowEmpty() {
-        ReferrerFilter rf = new ReferrerFilter(createConfiguration(true, null, null, null, null),
-                Collections.emptyList());
+        ReferrerFilter rf =
+                new ReferrerFilter(createConfiguration(true, null, null, null, null), Collections.emptyList());
 
         assertTrue(rf.isValidRequest(getRequest(null, null, "/test_path")));
         assertTrue(rf.isValidRequest(getRequest("", null, null)));
@@ -232,7 +239,8 @@ public class ReferrerFilterTest {
 
     @Test
     public void testIsBrowserRequest() {
-        String userAgent = "Mozilla/5.0;Some-Agent (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/603.2.4 (KHTML, like Gecko)";
+        String userAgent =
+                "Mozilla/5.0;Some-Agent (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/603.2.4 (KHTML, like Gecko)";
         assertFalse(filter.isBrowserRequest(getRequest(null, userAgent)));
         userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/603.2.4 (KHTML, like Gecko)";
         assertTrue(filter.isBrowserRequest(getRequest(null, userAgent)));


### PR DESCRIPTION
Upgrades the Apache Sling Security bundle to use `sling-bundle-parent` v66 and configures Java 11 as the minimum runtime version, along with several related dependency and code hygiene fixes.

**Changes:**
- Bump `sling-bundle-parent` from `46` to `66`
- Set `sling.java.version` to `11` and update `project.build.outputTimestamp` to ISO-8601 format
- Fix `pom.xml` encoding declaration from `ISO-8859-1` to `UTF-8`
- Add explicit `provided` scope to OSGi, servlet, and SLF4J dependencies
- Add explicit `test` scope to `junit` and `slf4j-simple`
- Replace `mockito-all:1.10.19` with `mockito-core:4.11.0`
- Remove unused `osgi.core` dependency
- Reorder imports (javax before java) and reformat annotations in `ContentDispositionFilter.java`
- Reformat `ContentDispositionFilterConfiguration.java` (diff truncated; partial view)
- Various whitespace and comment style cleanups across source files

Co-authored-by: Maia <maia@noreply>